### PR TITLE
Upgrade to confluent version 5.5.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,8 +21,8 @@ repositories {
 }
 
 dependencies{
-    val confluentVersion by extra("5.5.0")
-    val avroVersion by extra("1.9.2")
+    val confluentVersion by extra("5.5.1")
+    val avroVersion by extra("1.10.0")
     val junitVersion by extra("5.6.2")
     val logbackVersion by extra("1.2.3")
     implementation("org.apache.avro:avro:${avroVersion}")


### PR DESCRIPTION
Our dev team are great fans of this dev library. We're looking to upgrade to confluent version 5.5.1 and avro version 1.10.0

Not sure if the dependency to com.sksamuel.avro4k:avro4k-core 0.30.0 (which points to confluent 5.5.0) will need to be updated first?