### PR TITLE
Allow providing a custom Avro instance instead of using Avro.default

### DIFF
--- a/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/AbstractKafkaAvro4kDeserializer.kt
+++ b/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/AbstractKafkaAvro4kDeserializer.kt
@@ -16,7 +16,7 @@ import java.io.IOException
 import java.io.InputStream
 import kotlin.reflect.KClass
 
-abstract class AbstractKafkaAvro4kDeserializer : AbstractKafkaAvro4kSerDe() {
+abstract class AbstractKafkaAvro4kDeserializer(private val avro: Avro) : AbstractKafkaAvro4kSerDe() {
     companion object {
         private var specificRecordLookupForClassLoader: MutableMap<Pair<List<String>, ClassLoader>, RecordLookup> =
             mutableMapOf()
@@ -28,7 +28,7 @@ abstract class AbstractKafkaAvro4kDeserializer : AbstractKafkaAvro4kSerDe() {
 
     private var recordPackages: List<String> = emptyList()
     private var binaryDecoder: BinaryDecoder? = null
-    protected val avroSchemaUtils = Avro4kSchemaUtils()
+    protected val avroSchemaUtils = Avro4kSchemaUtils(avro)
 
 
     protected fun configure(config: KafkaAvro4kDeserializerConfig) {
@@ -110,7 +110,7 @@ abstract class AbstractKafkaAvro4kDeserializer : AbstractKafkaAvro4kSerDe() {
         bytes: InputStream
     ): Any {
         val deserializedClass = getDeserializedClass(writerSchema)
-        return Avro.default.openInputStream(deserializedClass.serializer()) {
+        return avro.openInputStream(deserializedClass.serializer()) {
             decodeFormat = AvroDecodeFormat.Binary(
                 writerSchema = writerSchema,
                 readerSchema = readerSchema ?: avroSchemaUtils.getSchema(deserializedClass)

--- a/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/AbstractKafkaAvro4kSerializer.kt
+++ b/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/AbstractKafkaAvro4kSerializer.kt
@@ -15,10 +15,10 @@ import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.nio.ByteBuffer
 
-abstract class AbstractKafkaAvro4kSerializer : AbstractKafkaAvro4kSerDe() {
+abstract class AbstractKafkaAvro4kSerializer(private val avro: Avro) : AbstractKafkaAvro4kSerDe() {
     private var autoRegisterSchema = false
 
-    protected val avroSchemaUtils = Avro4kSchemaUtils()
+    protected val avroSchemaUtils = Avro4kSchemaUtils(avro)
     protected fun configure(config: KafkaAvro4kSerializerConfig) {
         autoRegisterSchema = config.autoRegisterSchema()
         super.configure(config)
@@ -60,7 +60,7 @@ abstract class AbstractKafkaAvro4kSerializer : AbstractKafkaAvro4kSerDe() {
             if (obj is NonRecordContainer) obj.value else obj
         if (currentSchema.type == Schema.Type.RECORD) {
             @Suppress("UNCHECKED_CAST")
-            Avro.default.openOutputStream(value::class.serializer() as KSerializer<Any>) {
+            avro.openOutputStream(value::class.serializer() as KSerializer<Any>) {
                 encodeFormat = AvroEncodeFormat.Binary
                 schema = currentSchema
             }.to(out).write(obj).close()

--- a/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/Avro4kSchemaUtils.kt
+++ b/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/Avro4kSchemaUtils.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.isSuperclassOf
 
 
-class Avro4kSchemaUtils {
+class Avro4kSchemaUtils(private val avro: Avro) {
     private val NULL_SCHEMA = Schema.create(Schema.Type.NULL)
     private val BOOLEAN_SCHEMA = Schema.create(Schema.Type.BOOLEAN)
     private val INTEGER_SCHEMA = Schema.create(Schema.Type.INT)
@@ -31,7 +31,7 @@ class Avro4kSchemaUtils {
             Double::class.isSuperclassOf(clazz) -> DOUBLE_SCHEMA
             CharSequence::class.isSuperclassOf(clazz) -> STRING_SCHEMA
             ByteArray::class.isSuperclassOf(clazz) -> BYTES_SCHEMA
-            else -> cachedSchemas.computeIfAbsent(clazz) { Avro.default.schema(it.serializer()) }
+            else -> cachedSchemas.computeIfAbsent(clazz) { avro.schema(it.serializer()) }
         }
     }
 

--- a/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/Avro4kSerde.kt
+++ b/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/Avro4kSerde.kt
@@ -1,16 +1,17 @@
 package com.github.thake.kafka.avro4k.serializer
 
+import com.github.avrokotlin.avro4k.Avro
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import org.apache.kafka.common.serialization.Deserializer
 import org.apache.kafka.common.serialization.Serde
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.common.serialization.Serializer
 
-class Avro4kSerde<T : Any?>(client: SchemaRegistryClient? = null) : Serde<T> {
+class Avro4kSerde<T : Any?>(client: SchemaRegistryClient? = null, avro: Avro = Avro.default) : Serde<T> {
     @Suppress("UNCHECKED_CAST")
     private val inner: Serde<T> = Serdes.serdeFrom(
-        KafkaAvro4kSerializer(client) as Serializer<T>,
-        KafkaAvro4kDeserializer(client) as Deserializer<T>
+        KafkaAvro4kSerializer(client, avro = avro) as Serializer<T>,
+        KafkaAvro4kDeserializer(client, avro = avro) as Deserializer<T>
     )
 
 

--- a/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/KafkaAvro4kDeserializer.kt
+++ b/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/KafkaAvro4kDeserializer.kt
@@ -1,13 +1,15 @@
 package com.github.thake.kafka.avro4k.serializer
 
+import com.github.avrokotlin.avro4k.Avro
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import org.apache.avro.Schema
 import org.apache.kafka.common.serialization.Deserializer
 
 class KafkaAvro4kDeserializer(
     client: SchemaRegistryClient? = null,
-    props: Map<String, *>? = null
-) : AbstractKafkaAvro4kDeserializer(), Deserializer<Any?> {
+    props: Map<String, *>? = null,
+    avro: Avro = Avro.default
+) : AbstractKafkaAvro4kDeserializer(avro), Deserializer<Any?> {
     private var isKey = false
 
     init {

--- a/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/KafkaAvro4kSerializer.kt
+++ b/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/KafkaAvro4kSerializer.kt
@@ -1,13 +1,15 @@
 package com.github.thake.kafka.avro4k.serializer
 
+import com.github.avrokotlin.avro4k.Avro
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import org.apache.kafka.common.serialization.Serializer
 
 class KafkaAvro4kSerializer(
     client : SchemaRegistryClient? = null,
-    props : Map<String,*>? = null
-) : AbstractKafkaAvro4kSerializer(), Serializer<Any?> {
+    props : Map<String,*>? = null,
+    avro: Avro = Avro.default
+) : AbstractKafkaAvro4kSerializer(avro), Serializer<Any?> {
     private var isKey = false
 
     init {

--- a/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/TypedKafkaAvro4kDeserializer.kt
+++ b/src/main/kotlin/com/github/thake/kafka/avro4k/serializer/TypedKafkaAvro4kDeserializer.kt
@@ -1,5 +1,6 @@
 package com.github.thake.kafka.avro4k.serializer
 
+import com.github.avrokotlin.avro4k.Avro
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import org.apache.avro.Schema
 import org.apache.kafka.common.errors.SerializationException
@@ -7,7 +8,10 @@ import org.apache.kafka.common.serialization.Deserializer
 import kotlin.jvm.internal.Reflection
 import kotlin.reflect.KClass
 
-class TypedKafkaAvro4kDeserializer<T : Any>(private val type: Class<T>, client : SchemaRegistryClient? = null) : AbstractKafkaAvro4kDeserializer(), Deserializer<T> {
+class TypedKafkaAvro4kDeserializer<T : Any>(
+    private val type: Class<T>, client : SchemaRegistryClient? = null,
+    avro: Avro = Avro.default
+) : AbstractKafkaAvro4kDeserializer(avro), Deserializer<T> {
     private val typeNames = type.avroRecordNames
     init {
         this.schemaRegistry = client


### PR DESCRIPTION
Currently avro4k-kafka-serializer uses the static Avro.default instance, making it impossible to customise it. 
This change provides an option to pass a custom Avro instance within the constructor using Avro.default as default value.
It will allow defining the SerializersModule which is required for using ContextualSerialization, e.g. in our use case providing a contextual UUIDSerializer to serialize to a ByteArray instead of a String.